### PR TITLE
[fix][shell] "read" command에서 parameter check 오동작 수정

### DIFF
--- a/TestShellApplication-Test/test.cpp
+++ b/TestShellApplication-Test/test.cpp
@@ -56,7 +56,7 @@ TEST_F(TestShellApplicationTestFixture, ExceptionTestInvalidCharCase1) {
 
 
 TEST_F(TestShellApplicationTestFixture, ExceptionTestInvalidCharCase2) {
-	std::string strCommandLine = "read ABC\n";
+	std::string strCommandLine = "read 0ABD\n";
 	std::string strExpectedResult = "INVALID LBA\n";
 
 	EXPECT_CALL(ssdMock, Read)

--- a/TestShellApplication/ReadCommand.cpp
+++ b/TestShellApplication/ReadCommand.cpp
@@ -48,15 +48,12 @@ bool ReadCommand::_isDecimalFormat()
 
 bool ReadCommand::_isValidCharacter()
 {
-	try {
-		stoi(m_vCommandList[0]);
-		return true;
-	}
-	catch (const invalid_argument& e) {
-		//m_out << "Invalid argument: " << e.what() << endl;
+	for (const char ch : m_vCommandList[0]) {
+		if ((ch >= '0') && (ch <= '9')) continue;
 		m_out << "INVALID LBA\n";
 		return false;
 	}
+	return true;
 }
 
 void ReadCommand::_updateLBA()

--- a/TestShellApplication/ReadCommand.cpp
+++ b/TestShellApplication/ReadCommand.cpp
@@ -21,8 +21,7 @@ bool ReadCommand::_parseCommand() {
 bool ReadCommand::_checkValidityLBA()
 {
 	if (_hasEnoughArgs() == false) return false;
-	if (_isDecimalFormat() == false) return false;
-	if (_isValidCharacter() == false) return false;
+	if (_isValidFormat() == false) return false;
 	_updateLBA();
 	if (_isLBAInRange() == false) return false;
 	return true;
@@ -37,17 +36,12 @@ bool ReadCommand::_hasEnoughArgs()
 	return true;
 }
 
-bool ReadCommand::_isDecimalFormat()
+bool ReadCommand::_isValidFormat()
 {
 	if (m_vCommandList[0].substr(0, 2) == "0x") {
 		m_out << "INVALID LBA\n";
 		return false;
 	}
-	return true;
-}
-
-bool ReadCommand::_isValidCharacter()
-{
 	for (const char ch : m_vCommandList[0]) {
 		if ((ch >= '0') && (ch <= '9')) continue;
 		m_out << "INVALID LBA\n";

--- a/TestShellApplication/ReadCommand.h
+++ b/TestShellApplication/ReadCommand.h
@@ -12,8 +12,7 @@ protected:
 	bool _parseCommand() override;
 	bool _checkValidityLBA();
 	bool _hasEnoughArgs();
-	bool _isDecimalFormat();
-	bool _isValidCharacter();
+	bool _isValidFormat();
 	void _updateLBA();
 	bool _isLBAInRange();
 	void _execute() override;


### PR DESCRIPTION
stoi가 "0AB" 같이 시작은 올바르지만 중간부터 잘못 된 문자열이 나타나는 경우,
예외를 발생시키지 않고 읽을 수 있는 부분까지만 읽어서 반환하는 문제가 있어,
자체적인 방법을 적용하도록 수정하였습니다.