### PR TITLE
Logger 기능 추가 건

### DIFF
--- a/TestShellApplication/Logger.cpp
+++ b/TestShellApplication/Logger.cpp
@@ -1,0 +1,25 @@
+#include "Logger.h"
+
+#include <iostream>
+#include <iomanip>
+#include <ctime>
+#include <sstream>
+
+
+void Logger::print(string msg, string strCallerName)
+{
+    std::time_t now = std::time(nullptr);
+    std::tm localTime;
+    errno_t err = localtime_s(&localTime, &now);
+    std::ostringstream oss;
+    oss << std::put_time(&localTime, "[%y.%m.%d %H:%M]");
+    string strDate = oss.str();
+
+    std::ostringstream ossMessage;
+    strCallerName += "()";
+    ossMessage << std::setw(30) << std::left << strCallerName;
+    ossMessage << ": " << msg;
+    string strMessage = ossMessage.str();
+
+    std::cout << strDate << " " << strMessage << std::endl;
+}

--- a/TestShellApplication/Logger.cpp
+++ b/TestShellApplication/Logger.cpp
@@ -9,6 +9,12 @@
 #include <regex>
 
 
+Logger& Logger::getInstance()
+{
+    static Logger inst;
+    return inst;
+}
+
 Logger::Logger()
 	: m_os{ std::cout }
 {

--- a/TestShellApplication/Logger.cpp
+++ b/TestShellApplication/Logger.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <ctime>
 #include <sstream>
+#include <fstream>
 
 
 void Logger::print(string msg, string strCallerName)
@@ -21,5 +22,13 @@ void Logger::print(string msg, string strCallerName)
     ossMessage << ": " << msg;
     string strMessage = ossMessage.str();
 
-    std::cout << strDate << " " << strMessage << std::endl;
+    string strTotalMessage = strDate + " " + strMessage;
+
+    std::cout << strTotalMessage << std::endl;
+    std::ofstream ofs(".\\latest.log", std::ios::app);
+    if (ofs.is_open() == false) {
+        throw std::exception("Failed to open log file.");
+    }
+    ofs << strTotalMessage << std::endl;
+    ofs.close();
 }

--- a/TestShellApplication/Logger.cpp
+++ b/TestShellApplication/Logger.cpp
@@ -7,28 +7,55 @@
 #include <fstream>
 
 
-void Logger::print(string msg, string strCallerName)
+void Logger::Print(string strMessage, string strCallerName)
+{
+    _printMessageToConsole(strMessage);
+    _printMessageToLogFile(strMessage, strCallerName);
+}
+
+void Logger::_printMessageToConsole(const string& strMessage)
+{
+    std::cout << strMessage << std::endl;
+}
+
+void Logger::_printMessageToLogFile(const string& strMessage, const string& strCallerName)
+{
+    const string LOG_FILE_NAME = "latest.log";
+
+    string formatMessage = _makeFormatMessage(strCallerName, strMessage);
+
+    std::ofstream ofs(".\\" + LOG_FILE_NAME, std::ios::app);
+    if (ofs.is_open() == false) {
+        throw std::exception("Failed to open log file.");
+    }
+    ofs << formatMessage << std::endl;
+    ofs.close();
+}
+
+string Logger::_makeFormatMessage(const string& strCallerName, const string& msg)
+{
+    return _getDateString() + " " + _getFormatMessage(strCallerName, msg);
+}
+
+string Logger::_getDateString()
 {
     std::time_t now = std::time(nullptr);
     std::tm localTime;
     errno_t err = localtime_s(&localTime, &now);
     std::ostringstream oss;
     oss << std::put_time(&localTime, "[%y.%m.%d %H:%M]");
-    string strDate = oss.str();
+
+    return oss.str();
+}
+
+string Logger::_getFormatMessage(string strCallerName, const string& msg)
+{
+    constexpr int FORMAT_MESAGE_SIZE = 30;
 
     std::ostringstream ossMessage;
     strCallerName += "()";
-    ossMessage << std::setw(30) << std::left << strCallerName;
+    ossMessage << std::setw(FORMAT_MESAGE_SIZE) << std::left << strCallerName;
     ossMessage << ": " << msg;
-    string strMessage = ossMessage.str();
 
-    string strTotalMessage = strDate + " " + strMessage;
-
-    std::cout << strTotalMessage << std::endl;
-    std::ofstream ofs(".\\latest.log", std::ios::app);
-    if (ofs.is_open() == false) {
-        throw std::exception("Failed to open log file.");
-    }
-    ofs << strTotalMessage << std::endl;
-    ofs.close();
+    return ossMessage.str();
 }

--- a/TestShellApplication/Logger.cpp
+++ b/TestShellApplication/Logger.cpp
@@ -5,6 +5,7 @@
 #include <ctime>
 #include <sstream>
 #include <fstream>
+#include <windows.h>
 
 
 void Logger::Print(string strMessage, string strCallerName)
@@ -20,8 +21,6 @@ void Logger::_printMessageToConsole(const string& strMessage)
 
 void Logger::_printMessageToLogFile(const string& strMessage, const string& strCallerName)
 {
-    const string LOG_FILE_NAME = "latest.log";
-
     string formatMessage = _makeFormatMessage(strCallerName, strMessage);
 
     std::ofstream ofs(".\\" + LOG_FILE_NAME, std::ios::app);
@@ -30,6 +29,21 @@ void Logger::_printMessageToLogFile(const string& strMessage, const string& strC
     }
     ofs << formatMessage << std::endl;
     ofs.close();
+
+    long long llFileSize = _getLogFileSize();
+    if (llFileSize > 10 * 1024) {
+        string strNewFileName;
+        std::time_t now = std::time(nullptr);
+        std::tm localTime;
+        errno_t err = localtime_s(&localTime, &now);
+        std::ostringstream oss;
+        oss << std::put_time(&localTime, "until_%y%m%d_%Hh_%Mm_%Ss.log");
+        strNewFileName = oss.str();
+
+        if (MoveFileA(LOG_FILE_NAME.c_str(), strNewFileName.c_str()) == FALSE) {
+            throw std::exception("Failed to make old log file");
+        }
+    }
 }
 
 string Logger::_makeFormatMessage(const string& strCallerName, const string& msg)
@@ -58,4 +72,13 @@ string Logger::_getFormatMessage(string strCallerName, const string& msg)
     ossMessage << ": " << msg;
 
     return ossMessage.str();
+}
+
+long long Logger::_getLogFileSize()
+{
+    std::ifstream file(LOG_FILE_NAME, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+        throw std::exception("Failed to open log file.");
+    }
+    return file.tellg();
 }

--- a/TestShellApplication/Logger.cpp
+++ b/TestShellApplication/Logger.cpp
@@ -9,6 +9,11 @@
 #include <regex>
 
 
+Logger::Logger()
+	: m_os{ std::cout }
+{
+}
+
 void Logger::Print(string strMessage, string strCallerName)
 {
     _printMessageToConsole(strMessage);
@@ -32,6 +37,11 @@ void Logger::_printMessageToLogFile(const string& strMessage, const string& strC
     ofs.close();
 
     _splitLogFileOnSize();
+}
+
+void Logger::SetOutStream(std::ostream& os)
+{
+    m_os.rdbuf(os.rdbuf());
 }
 
 string Logger::_makeFormatMessage(const string& strCallerName, const string& msg)

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -6,9 +6,15 @@
 using std::string;
 using std::vector;
 
+#define LOG(msg) Logger::getInstance().Print(msg, __FUNCTION__);
+
+
 class Logger
 {
 public:
+	static Logger& getInstance();
+
+private:
 	Logger();
 	virtual ~Logger() = default;
 

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+using std::string;
+
+class Logger
+{
+public:
+	Logger() = default;
+	virtual ~Logger() = default;
+
+public:
+	void print(string msg, string strCallerName);
+};

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -18,4 +18,8 @@ private:
 	string _makeFormatMessage(const string& strCallerName, const string& msg);
 	string _getDateString();
 	string _getFormatMessage(string strCallerName, const string& msg);
+	long long _getLogFileSize();
+
+private:
+	const string LOG_FILE_NAME = "latest.log";
 };

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <string>
+#include <vector>
+
 using std::string;
+using std::vector;
 
 class Logger
 {
@@ -19,6 +22,8 @@ private:
 	string _getDateString();
 	string _getFormatMessage(string strCallerName, const string& msg);
 	long long _getLogFileSize();
+	vector<string> _getOldLogFiles(const string& strNewFileName);
+	void _compressLogFile(const string& strFileName);
 
 private:
 	const string LOG_FILE_NAME = "latest.log";

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -21,7 +21,11 @@ private:
 	string _makeFormatMessage(const string& strCallerName, const string& msg);
 	string _getDateString();
 	string _getFormatMessage(string strCallerName, const string& msg);
+	void _splitLogFileOnSize();
+	bool _isNeedToSplitLogFile();
 	long long _getLogFileSize();
+	string _getNewBackupLogFileName();
+	void _checkAndCompressOldLogFiles(const string& strNewFileName);
 	vector<string> _getOldLogFiles(const string& strNewFileName);
 	void _compressLogFile(const string& strFileName);
 

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -9,12 +9,13 @@ using std::vector;
 class Logger
 {
 public:
-	Logger() = default;
+	Logger();
 	virtual ~Logger() = default;
 
 public:
 	void Print(string strMessage, string strCallerName);
 	inline void EnableConsoleLog(bool b) { m_bEnableConsoleLog = b; }
+	void SetOutStream(std::ostream& os);
 
 private:
 	void _printMessageToConsole(const string& strMessage);
@@ -33,4 +34,5 @@ private:
 private:
 	const string LOG_FILE_NAME = "latest.log";
 	bool m_bEnableConsoleLog = true;
+	std::ostream& m_os;
 };

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -14,6 +14,7 @@ public:
 
 public:
 	void Print(string strMessage, string strCallerName);
+	inline void EnableConsoleLog(bool b) { m_bEnableConsoleLog = b; }
 
 private:
 	void _printMessageToConsole(const string& strMessage);
@@ -31,4 +32,5 @@ private:
 
 private:
 	const string LOG_FILE_NAME = "latest.log";
+	bool m_bEnableConsoleLog = true;
 };

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -10,5 +10,12 @@ public:
 	virtual ~Logger() = default;
 
 public:
-	void print(string msg, string strCallerName);
+	void Print(string strMessage, string strCallerName);
+
+private:
+	void _printMessageToConsole(const string& strMessage);
+	void _printMessageToLogFile(const string& strMessage, const string& strCallerName);
+	string _makeFormatMessage(const string& strCallerName, const string& msg);
+	string _getDateString();
+	string _getFormatMessage(string strCallerName, const string& msg);
 };

--- a/TestShellApplication/TestShellApplication.vcxproj
+++ b/TestShellApplication/TestShellApplication.vcxproj
@@ -136,6 +136,7 @@
     <ClCompile Include="FullWriteCommand.cpp" />
     <ClCompile Include="HelpCommand.cpp" />
     <ClCompile Include="InvalidCommand.cpp" />
+    <ClCompile Include="Logger.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ReadCommand.cpp" />
     <ClCompile Include="Shell.cpp" />
@@ -152,6 +153,7 @@
     <ClInclude Include="FullWriteCommand.h" />
     <ClInclude Include="HelpCommand.h" />
     <ClInclude Include="InvalidCommand.h" />
+    <ClInclude Include="Logger.h" />
     <ClInclude Include="ReadCommand.h" />
     <ClInclude Include="Shell.h" />
     <ClInclude Include="SSDCommandInvoker.h" />

--- a/TestShellApplication/TestShellApplication.vcxproj.filters
+++ b/TestShellApplication/TestShellApplication.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="TestApp2Command.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="Logger.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="SSDCommand.h">
@@ -104,6 +107,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="TestApp2Command.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="Logger.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Shell의 Logger 기능 추가 PR 입니다.

Logger라는 Singleton class를 사용하였으며, 아래와 같은 3가지 public method를 사용할 수 있습니다.

``` c++
void Print(string strMessage, string strCallerName);
void EnableConsoleLog(bool b);
void SetOutStream(std::ostream& os);
```

1. Print() - 메세지를 Logging하는 함수
2. EnableConsoleLog() - Console 출력 여부를 결정할 수 있는 함수 -> Runner에서 disable용으로 사용
3. SetOutStream() - std::ostream을 변경할 수 있는 함수 (default: std::cout) -> gtest에 적용할 수 있도록 하기 위하여 구현

추가로 Print() 함수에서는 Print() 함수를 호출하는 함수의 이름 (클래스명::함수명)을 출력해야 하는데,
해당 인자로 `__FUNCTION__` 매크로를 사용하면 됩니다.
매크로는 default parameter로 설정하려 하였으나, 해당 매크로는 함수 본문에서만 사용 가능한 macro여서
Print() 함수를 사용할 수 있는 `LOG()` 라는 매크로 함수를 Logger.h에 추가하였습니다.

그래서 사용하실 때는 `Logger.h` 헤더파일을 include 하시고,
`LOG()` 매크로 함수를 통하여 사용하시면 됩니다.

관련하여 질문이 있으시면 말씀 부탁드립니다. 