### PR TITLE
[refactoring][shell][log] 다른 형태의 Logger가 추가될 수 있도록 구현

### DIFF
--- a/TestShellApplication/FileLoggerPrinter.cpp
+++ b/TestShellApplication/FileLoggerPrinter.cpp
@@ -1,0 +1,155 @@
+#include "FileLoggerPrinter.h"
+
+#include <iomanip>
+#include <ctime>
+#include <sstream>
+#include <fstream>
+#include <windows.h>
+#include <regex>
+
+
+FileLoggerPrinter::FileLoggerPrinter(string rootPath)
+	: m_strRootPath(rootPath)
+{
+    _createRootDirectory();
+}
+
+void FileLoggerPrinter::Print(string strMessage, string strCallerName)
+{
+    string formatMessage = _makeFormatMessage(strCallerName, strMessage);
+
+    std::ofstream ofs(m_strRootPath + LOG_FILE_NAME, std::ios::app);
+    if (ofs.is_open() == false) {
+        throw std::exception("Failed to open log file.");
+    }
+    ofs << formatMessage << std::endl;
+    ofs.close();
+
+    _splitLogFileOnSize();
+}
+
+void FileLoggerPrinter::_createRootDirectory()
+{
+    CreateDirectoryA(m_strRootPath.c_str(), nullptr);
+}
+
+string FileLoggerPrinter::_makeFormatMessage(const string& strCallerName, const string& msg)
+{
+    return _getDateString() + " " + _getFormatMessage(strCallerName, msg);
+}
+
+string FileLoggerPrinter::_getDateString()
+{
+    std::time_t now = std::time(nullptr);
+    std::tm localTime;
+    errno_t err = localtime_s(&localTime, &now);
+    std::ostringstream oss;
+    oss << std::put_time(&localTime, "[%y.%m.%d %H:%M]");
+
+    return oss.str();
+}
+
+string FileLoggerPrinter::_getFormatMessage(string strCallerName, const string& msg)
+{
+    constexpr int FORMAT_MESAGE_SIZE = 30;
+
+    std::ostringstream ossMessage;
+    strCallerName += "()";
+    ossMessage << std::setw(FORMAT_MESAGE_SIZE) << std::left << strCallerName;
+    ossMessage << ": " << msg;
+
+    return ossMessage.str();
+}
+
+void FileLoggerPrinter::_splitLogFileOnSize()
+{
+    if (_isNeedToSplitLogFile() == false) {
+        return;
+    }
+    _createBackupLogFile();
+    _checkAndCompressOldBackupLogFiles();
+}
+
+bool FileLoggerPrinter::_isNeedToSplitLogFile()
+{
+    constexpr int MAX_LOG_FILE_SIZE = 10 * 1024;
+
+    long long llFileSize = _getLogFileSize();
+    if (llFileSize > MAX_LOG_FILE_SIZE) {
+        return true;
+    }
+    return false;
+}
+
+void FileLoggerPrinter::_createBackupLogFile()
+{
+    string logFilePath = m_strRootPath + LOG_FILE_NAME;
+    m_strBackupLogFileName = _getNewBackupLogFileName();
+    string strBackupLogFilePath = m_strRootPath + m_strBackupLogFileName;
+    if (MoveFileA(logFilePath.c_str(), strBackupLogFilePath.c_str()) == FALSE) {
+        throw std::exception("Failed to make backup log file");
+    }
+}
+
+long long FileLoggerPrinter::_getLogFileSize()
+{
+    string logFilePath = m_strRootPath + LOG_FILE_NAME;
+    std::ifstream file(logFilePath.c_str(), std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+        throw std::exception("Failed to open log file.");
+    }
+    return file.tellg();
+}
+
+string FileLoggerPrinter::_getNewBackupLogFileName()
+{
+    const string LOG_FILE_NAME_FORMAT = "until_%y%m%d_%Hh_%Mm_%Ss.log";
+
+    std::time_t now = std::time(nullptr);
+    std::tm localTime;
+    errno_t err = localtime_s(&localTime, &now);
+    std::ostringstream oss;
+    oss << std::put_time(&localTime, LOG_FILE_NAME_FORMAT.c_str());
+
+    return oss.str();
+}
+
+void FileLoggerPrinter::_checkAndCompressOldBackupLogFiles()
+{
+    vector<string> vOldLogFiles = _getOldBackupLogFiles();
+    for (string oldLogFile : vOldLogFiles) {
+        _compressLogFile(oldLogFile);
+    }
+}
+
+vector<string> FileLoggerPrinter::_getOldBackupLogFiles() {
+    WIN32_FIND_DATAA findData;
+    HANDLE hFind = FindFirstFileA((m_strRootPath + "*.log").c_str(), &findData);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        return vector<string>();
+    }
+
+    vector<string> vFileList;
+    std::regex regexFilter("until_\\d{6}_\\d{2}h_\\d{2}m_\\d{2}s\\.log");
+    do {
+        std::string strFileName = findData.cFileName;
+        if (std::regex_match(strFileName, regexFilter)) {
+            if (strFileName == m_strBackupLogFileName) continue;
+            vFileList.push_back(strFileName);
+        }
+    } while (FindNextFileA(hFind, &findData) != 0);
+    FindClose(hFind);
+
+    return vFileList;
+}
+
+void FileLoggerPrinter::_compressLogFile(const string& strFileName)
+{
+    auto nPos = strFileName.find_last_of('.');
+    string strCompressedFilePath = m_strRootPath + strFileName.substr(0, nPos) + ".zip";
+ 
+    string originFilePath = m_strRootPath + strFileName;
+    if (MoveFileA(originFilePath.c_str(), strCompressedFilePath.c_str()) == FALSE) {
+        throw std::exception("Failed to compress old backup log file");
+    }
+}

--- a/TestShellApplication/FileLoggerPrinter.h
+++ b/TestShellApplication/FileLoggerPrinter.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "LoggerPrinter.h"
+
+#include <vector>
+using std::vector;
+
+class FileLoggerPrinter :
+    public LoggerPrinter
+{
+public:
+    FileLoggerPrinter() = delete;
+    FileLoggerPrinter(string strRootPath = ".\\");
+
+public:
+    void Print(string strMessage, string strCallerName) override;
+
+private:
+	void _createRootDirectory();
+	string _makeFormatMessage(const string& strCallerName, const string& msg);
+	string _getDateString();
+	string _getFormatMessage(string strCallerName, const string& msg);
+	void _splitLogFileOnSize();
+	bool _isNeedToSplitLogFile();
+	void _createBackupLogFile();
+	long long _getLogFileSize();
+	string _getNewBackupLogFileName();
+	void _checkAndCompressOldBackupLogFiles();
+	vector<string> _getOldBackupLogFiles();
+	void _compressLogFile(const string& strFileName);
+
+
+private:
+    const string m_strRootPath;
+    const string LOG_FILE_NAME = "latest.log";
+	string m_strBackupLogFileName = "";
+};
+

--- a/TestShellApplication/Logger.cpp
+++ b/TestShellApplication/Logger.cpp
@@ -16,150 +16,41 @@ Logger& Logger::getInstance()
 }
 
 Logger::Logger()
-	: m_os{ std::cout }
+    : m_fileLoggerPrinter{".\\log\\"}
 {
+    AddLoggerPrinter(&m_outStreamLoggerPrinter);
+    AddLoggerPrinter(&m_fileLoggerPrinter);
 }
 
 void Logger::Print(string strMessage, string strCallerName)
 {
-    _printMessageToConsole(strMessage);
-    _printMessageToLogFile(strMessage, strCallerName);
-}
-
-void Logger::_printMessageToConsole(const string& strMessage)
-{
-    std::cout << strMessage << std::endl;
-}
-
-void Logger::_printMessageToLogFile(const string& strMessage, const string& strCallerName)
-{
-    string formatMessage = _makeFormatMessage(strCallerName, strMessage);
-
-    std::ofstream ofs(".\\" + LOG_FILE_NAME, std::ios::app);
-    if (ofs.is_open() == false) {
-        throw std::exception("Failed to open log file.");
+    for (const auto printer : m_vLoggerPrinters) {
+        printer->Print(strMessage, strCallerName);
     }
-    ofs << formatMessage << std::endl;
-    ofs.close();
+}
 
-    _splitLogFileOnSize();
+void Logger::EnableConsoleLog(bool b)
+{
+    m_outStreamLoggerPrinter.Enable(b);
 }
 
 void Logger::SetOutStream(std::ostream& os)
 {
-    m_os.rdbuf(os.rdbuf());
+    m_outStreamLoggerPrinter.SetOutStream(os);
 }
 
-string Logger::_makeFormatMessage(const string& strCallerName, const string& msg)
+void Logger::AddLoggerPrinter(LoggerPrinter* p)
 {
-    return _getDateString() + " " + _getFormatMessage(strCallerName, msg);
+    auto iterFind = std::find(m_vLoggerPrinters.begin(), m_vLoggerPrinters.end(), p);
+    if (iterFind != m_vLoggerPrinters.end()) return;
+    
+    m_vLoggerPrinters.push_back(p);
 }
 
-string Logger::_getDateString()
+void Logger::RemoveLoggerPrinter(LoggerPrinter* p)
 {
-    std::time_t now = std::time(nullptr);
-    std::tm localTime;
-    errno_t err = localtime_s(&localTime, &now);
-    std::ostringstream oss;
-    oss << std::put_time(&localTime, "[%y.%m.%d %H:%M]");
+    auto iterFind = std::find(m_vLoggerPrinters.begin(), m_vLoggerPrinters.end(), p);
+    if (iterFind == m_vLoggerPrinters.end()) return;
 
-    return oss.str();
-}
-
-string Logger::_getFormatMessage(string strCallerName, const string& msg)
-{
-    constexpr int FORMAT_MESAGE_SIZE = 30;
-
-    std::ostringstream ossMessage;
-    strCallerName += "()";
-    ossMessage << std::setw(FORMAT_MESAGE_SIZE) << std::left << strCallerName;
-    ossMessage << ": " << msg;
-
-    return ossMessage.str();
-}
-
-void Logger::_splitLogFileOnSize()
-{
-    if (_isNeedToSplitLogFile() == false) {
-        return;
-	}
-
-    string strBackupLogFileName = _getNewBackupLogFileName();
-	if (MoveFileA(LOG_FILE_NAME.c_str(), strBackupLogFileName.c_str()) == FALSE) {
-		throw std::exception("Failed to make old log file");
-	}
-
-    _checkAndCompressOldLogFiles(strBackupLogFileName);
-}
-
-bool Logger::_isNeedToSplitLogFile()
-{
-    constexpr int MAX_LOG_FILE_SIZE = 10 * 1024;
-
-    long long llFileSize = _getLogFileSize();
-    if (llFileSize > MAX_LOG_FILE_SIZE) {
-        return true;
-    }
-    return false;
-}
-
-long long Logger::_getLogFileSize()
-{
-    std::ifstream file(LOG_FILE_NAME, std::ios::binary | std::ios::ate);
-    if (!file.is_open()) {
-        throw std::exception("Failed to open log file.");
-    }
-    return file.tellg();
-}
-
-string Logger::_getNewBackupLogFileName()
-{
-    const string LOG_FILE_NAME_FORMAT = "until_%y%m%d_%Hh_%Mm_%Ss.log";
-
-    std::time_t now = std::time(nullptr);
-    std::tm localTime;
-    errno_t err = localtime_s(&localTime, &now);
-    std::ostringstream oss;
-    oss << std::put_time(&localTime, LOG_FILE_NAME_FORMAT.c_str());
- 
-    return oss.str();
-}
-
-void Logger::_checkAndCompressOldLogFiles(const string& strNewFileName)
-{
-    vector<string> vOldLogFiles = _getOldLogFiles(strNewFileName);
-    for (string oldLogFile : vOldLogFiles) {
-        _compressLogFile(oldLogFile);
-    }
-}
-
-vector<string> Logger::_getOldLogFiles(const string& strNewFileName) {
-    WIN32_FIND_DATAA findData;
-    HANDLE hFind = FindFirstFileA(".\\*.log", &findData);
-    if (hFind == INVALID_HANDLE_VALUE) {
-        return vector<string>();
-    }
-
-    vector<string> vFileList;
-    std::regex regexFilter("until_\\d{6}_\\d{2}h_\\d{2}m_\\d{2}s\\.log");
-    do {
-        std::string strFileName = findData.cFileName;
-        if (std::regex_match(strFileName, regexFilter)) {
-            if (strFileName == strNewFileName) continue;
-            vFileList.push_back(strFileName);
-        }
-    } while (FindNextFileA(hFind, &findData) != 0);
-    FindClose(hFind);
-
-    return vFileList;
-}
-
-void Logger::_compressLogFile(const string& strFileName)
-{
-    auto nPos = strFileName.find_last_of('.');
-    string strCompressedName = strFileName.substr(0, nPos) + ".zip";
-
-    if (MoveFileA(strFileName.c_str(), strCompressedName.c_str()) == FALSE) {
-        throw std::exception("Failed to compress old log file");
-    }
+    m_vLoggerPrinters.erase(iterFind);
 }

--- a/TestShellApplication/Logger.h
+++ b/TestShellApplication/Logger.h
@@ -1,4 +1,7 @@
 #pragma once
+#include "LoggerPrinter.h"
+#include "OutstreamLoggerPrinter.h"
+#include "FileLoggerPrinter.h"
 
 #include <string>
 #include <vector>
@@ -20,25 +23,14 @@ private:
 
 public:
 	void Print(string strMessage, string strCallerName);
-	inline void EnableConsoleLog(bool b) { m_bEnableConsoleLog = b; }
+	void EnableConsoleLog(bool b);
 	void SetOutStream(std::ostream& os);
 
-private:
-	void _printMessageToConsole(const string& strMessage);
-	void _printMessageToLogFile(const string& strMessage, const string& strCallerName);
-	string _makeFormatMessage(const string& strCallerName, const string& msg);
-	string _getDateString();
-	string _getFormatMessage(string strCallerName, const string& msg);
-	void _splitLogFileOnSize();
-	bool _isNeedToSplitLogFile();
-	long long _getLogFileSize();
-	string _getNewBackupLogFileName();
-	void _checkAndCompressOldLogFiles(const string& strNewFileName);
-	vector<string> _getOldLogFiles(const string& strNewFileName);
-	void _compressLogFile(const string& strFileName);
+	void AddLoggerPrinter(LoggerPrinter* p);
+	void RemoveLoggerPrinter(LoggerPrinter* p);
 
 private:
-	const string LOG_FILE_NAME = "latest.log";
-	bool m_bEnableConsoleLog = true;
-	std::ostream& m_os;
+	vector<LoggerPrinter*> m_vLoggerPrinters;
+	OutstreamLoggerPrinter m_outStreamLoggerPrinter;
+	FileLoggerPrinter m_fileLoggerPrinter;
 };

--- a/TestShellApplication/LoggerPrinter.h
+++ b/TestShellApplication/LoggerPrinter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+using std::string;
+
+#define interface struct
+
+interface LoggerPrinter
+{
+public:
+	virtual ~LoggerPrinter() {}
+
+public:
+	virtual void Print(string strMessage, string strCallerName) = 0;
+};

--- a/TestShellApplication/OutstreamLoggerPrinter.cpp
+++ b/TestShellApplication/OutstreamLoggerPrinter.cpp
@@ -1,0 +1,20 @@
+#include "OutstreamLoggerPrinter.h"
+
+#include <iostream>
+
+
+OutstreamLoggerPrinter::OutstreamLoggerPrinter()
+	: m_os{ std::cout }
+{
+}
+
+void OutstreamLoggerPrinter::Print(string strMessage, string strCallerName)
+{
+	if (_isEnable() == false) return;
+	m_os << strMessage << std::endl;
+}
+
+void OutstreamLoggerPrinter::SetOutStream(std::ostream& os)
+{
+	m_os.rdbuf(os.rdbuf());
+}

--- a/TestShellApplication/OutstreamLoggerPrinter.h
+++ b/TestShellApplication/OutstreamLoggerPrinter.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "LoggerPrinter.h"
+
+class OutstreamLoggerPrinter :
+    public LoggerPrinter
+{
+public:
+    OutstreamLoggerPrinter();
+
+public:
+    void Print(string strMessage, string strCallerName) override;
+
+    inline void Enable(bool b) { m_bEnable = b; }
+    void SetOutStream(std::ostream& os);
+
+private:
+    inline bool _isEnable() { return m_bEnable; }
+
+private:
+    bool m_bEnable = true;
+    std::ostream& m_os;
+};
+

--- a/TestShellApplication/TestShellApplication.vcxproj
+++ b/TestShellApplication/TestShellApplication.vcxproj
@@ -132,12 +132,14 @@
   <ItemGroup>
     <ClCompile Include="DriverInterface.h" />
     <ClCompile Include="ExitCommand.cpp" />
+    <ClCompile Include="FileLoggerPrinter.cpp" />
     <ClCompile Include="FullReadCommand.cpp" />
     <ClCompile Include="FullWriteCommand.cpp" />
     <ClCompile Include="HelpCommand.cpp" />
     <ClCompile Include="InvalidCommand.cpp" />
     <ClCompile Include="Logger.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="OutstreamLoggerPrinter.cpp" />
     <ClCompile Include="ReadCommand.cpp" />
     <ClCompile Include="Shell.cpp" />
     <ClCompile Include="SSDCommand.cpp" />
@@ -149,11 +151,13 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ExitCommand.h" />
+    <ClInclude Include="FileLoggerPrinter.h" />
     <ClInclude Include="FullReadCommand.h" />
     <ClInclude Include="FullWriteCommand.h" />
     <ClInclude Include="HelpCommand.h" />
     <ClInclude Include="InvalidCommand.h" />
     <ClInclude Include="Logger.h" />
+    <ClInclude Include="OutstreamLoggerPrinter.h" />
     <ClInclude Include="ReadCommand.h" />
     <ClInclude Include="Shell.h" />
     <ClInclude Include="SSDCommandInvoker.h" />

--- a/TestShellApplication/TestShellApplication.vcxproj
+++ b/TestShellApplication/TestShellApplication.vcxproj
@@ -157,6 +157,7 @@
     <ClInclude Include="HelpCommand.h" />
     <ClInclude Include="InvalidCommand.h" />
     <ClInclude Include="Logger.h" />
+    <ClInclude Include="LoggerPrinter.h" />
     <ClInclude Include="OutstreamLoggerPrinter.h" />
     <ClInclude Include="ReadCommand.h" />
     <ClInclude Include="Shell.h" />

--- a/TestShellApplication/TestShellApplication.vcxproj.filters
+++ b/TestShellApplication/TestShellApplication.vcxproj.filters
@@ -127,5 +127,8 @@
     <ClInclude Include="OutstreamLoggerPrinter.h">
       <Filter>Logger</Filter>
     </ClInclude>
+    <ClInclude Include="LoggerPrinter.h">
+      <Filter>Logger</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/TestShellApplication/TestShellApplication.vcxproj.filters
+++ b/TestShellApplication/TestShellApplication.vcxproj.filters
@@ -13,6 +13,9 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Logger">
+      <UniqueIdentifier>{1e26a09f-fef8-451e-9abe-5a97dd7c54ce}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SSDCommand.cpp">
@@ -61,7 +64,13 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="Logger.cpp">
-      <Filter>소스 파일</Filter>
+      <Filter>Logger</Filter>
+    </ClCompile>
+    <ClCompile Include="OutstreamLoggerPrinter.cpp">
+      <Filter>Logger</Filter>
+    </ClCompile>
+    <ClCompile Include="FileLoggerPrinter.cpp">
+      <Filter>Logger</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -110,7 +119,13 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="Logger.h">
-      <Filter>헤더 파일</Filter>
+      <Filter>Logger</Filter>
+    </ClInclude>
+    <ClInclude Include="FileLoggerPrinter.h">
+      <Filter>Logger</Filter>
+    </ClInclude>
+    <ClInclude Include="OutstreamLoggerPrinter.h">
+      <Filter>Logger</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
이전 구조에서는
Logger에서 Outstream과 File을 모두 관리하는 큰 클래스였습니다.

그래서 만약 다른 형태의 Logger를 추가한다면 Logger 자체를 변경해야 하기 때문에
유지보수에 힘들다는 문제가 있습니다.

아래와 같이 LoggerPrinter interface를 생성하고,
OutStreamLoggerPrinter와 FileLoggerPrinter가 해당 interface를 구현하고,
Logger에서는 LoggerPrinter interface를 사용하도록 구현하였습니다.

물론 기본적인 상세가 있기 때문에,
Logger가 초기에 두 printer들을 가지고 있습니다.

다만 향후에 상세가 변경되거나 하여 Printer가 추가되어야 한다면,
LoggerPrinter를 구현하는 별도의 class을 만들어서 Logger에 추가하기만 하면 됩니다.

![image](https://github.com/Yuhaa/SSD_E/assets/28858749/262fa8fe-3adb-42f8-8144-0d0099969bc9)
 