### PR TITLE
[shell] TestLibrary / TestScript에 Logger 적용

### DIFF
--- a/TestShellApplication-Test/test.cpp
+++ b/TestShellApplication-Test/test.cpp
@@ -1,6 +1,9 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
+#include "Logger.cpp"
+#include "OutstreamLoggerPrinter.cpp"
+#include "FileLoggerPrinter.cpp"
 #include "TestScripts/TestScriptBase.cpp"
 #include "TestScripts/TestApp1.cpp"
 #include "TestScripts/TestApp2.cpp"
@@ -44,6 +47,8 @@ public:
 
 protected:
 	void SetUp() override {
+		Logger::getInstance().SetOutStream(output);
+
 		EXPECT_CALL(mockDevice, GetMinLba)
 			.WillRepeatedly(Return(0));
 		EXPECT_CALL(mockDevice, GetMaxLba)

--- a/TestShellApplication/Shell.cpp
+++ b/TestShellApplication/Shell.cpp
@@ -1,14 +1,14 @@
 #include "Shell.h"
+#include "Logger.h"
 
 #include <sstream>
 #include <vector>
 
 Shell::Shell(DriverInterface* pstDriver)
-    : m_out(std::cout)
 {
-    m_pstTestLib = TestLibrary::GetLibrary(pstDriver, &m_out);
-    m_pstTestApp1 = new TestApp1(pstDriver, m_out);
-    m_pstTestApp2 = new TestApp2(pstDriver, m_out);
+    m_pstTestLib = TestLibrary::GetLibrary(pstDriver);
+    m_pstTestApp1 = new TestApp1(pstDriver);
+    m_pstTestApp2 = new TestApp2(pstDriver);
 }
 
 void Shell::Run(istream& input)
@@ -55,7 +55,7 @@ bool Shell::handleCommand(string strLine)
         return true;
     }
     else {
-        m_out << "INVALID COMMAND\n";
+        LOG("INVALID COMMAND");
     }
     return false;
 }

--- a/TestShellApplication/Shell.h
+++ b/TestShellApplication/Shell.h
@@ -19,7 +19,6 @@ public:
 	bool handleCommand(string lineString);
 
 private:
-	ostream& m_out;
 	TestLibrary* m_pstTestLib;
 	TestApp1* m_pstTestApp1;
 	TestApp2* m_pstTestApp2;

--- a/TestShellApplication/TestLibrary.cpp
+++ b/TestShellApplication/TestLibrary.cpp
@@ -1,12 +1,13 @@
 #include "TestLibrary.h"
 
+#include "Logger.h"
+
 TestLibrary* TestLibrary::m_Instance = nullptr;
 
-TestLibrary* TestLibrary::GetLibrary(DriverInterface* pstDriver, ostream* output)
+TestLibrary* TestLibrary::GetLibrary(DriverInterface* pstDriver)
 {
 	if (m_Instance == nullptr) m_Instance = new TestLibrary();
 	if (pstDriver != nullptr) m_Instance->m_pstDevice = new Device(pstDriver);
-	if (output != nullptr) m_Instance->m_out = output;
 	return m_Instance;
 }
 
@@ -16,7 +17,7 @@ void TestLibrary::Write(vector<string> vCommandList)
 		m_pstDevice->Write(vCommandList);
 	}
 	catch (exception e) {
-		*m_out << e.what() << endl;
+		LOG(e.what());
 	}
 }
 
@@ -29,7 +30,7 @@ void TestLibrary::Read(vector<string> vCommandList)
 	catch (exception e) {
 		ret = e.what();
 	}
-	*m_out << ret << endl;
+	LOG(ret);
 }
 
 void TestLibrary::FullWrite(vector<string> vCommandList)
@@ -42,7 +43,7 @@ void TestLibrary::FullWrite(vector<string> vCommandList)
 			m_pstDevice->Write(vCommandList);
 		}
 		catch (exception e) {
-			*m_out << e.what() << endl;
+			LOG(e.what());
 			return;
 		}
 	}
@@ -56,11 +57,10 @@ void TestLibrary::FullRead(string strExpected)
 			ret = m_pstDevice->Read({ to_string(nLBA) });
 			if (strExpected.size() == 10 && ret != strExpected)
 				throw runtime_error("Data Mismatch!!");
-			*m_out << ret << endl;
+			LOG(ret);
 		}
 		catch (exception e) {
-			ret = e.what();
-			*m_out << ret << endl;
+			LOG(e.what());
 			return;
 		}
 	}
@@ -73,7 +73,7 @@ void TestLibrary::WriteRange(int nStartLba, int nEndLba, string strData)
 			m_pstDevice->Write({to_string(nLBA), strData});
 		}
 		catch (exception e) {
-			*m_out << e.what() << endl;
+			LOG(e.what());
 			return;
 		}
 	}
@@ -87,10 +87,10 @@ void TestLibrary::ReadRange(int nStartLba, int nEndLba, string strExpected)
 			ret = m_pstDevice->Read({ to_string(nLBA) });
 			if (strExpected.size() == 10 && ret != strExpected)
 				throw runtime_error("Data Mismatch!!");
-			*m_out << ret << endl;
+			LOG(ret);
 		}
 		catch (exception e) {
-			*m_out << e.what() << endl;
+			LOG(e.what());
 			return;
 		}
 	}

--- a/TestShellApplication/TestLibrary.h
+++ b/TestShellApplication/TestLibrary.h
@@ -6,7 +6,7 @@
 
 class TestLibrary {
 public:
-	static TestLibrary* GetLibrary(DriverInterface * pstDevice = nullptr, ostream* output = nullptr);
+	static TestLibrary* GetLibrary(DriverInterface * pstDevice = nullptr);
 
 	void Write(vector<string> vCommandList);
 	void Read(vector<string> vCommandList);
@@ -23,5 +23,4 @@ private:
 
 	static TestLibrary* m_Instance;
 	Device* m_pstDevice;
-	ostream* m_out;
 };

--- a/TestShellApplication/TestScripts/TestApp1.cpp
+++ b/TestShellApplication/TestScripts/TestApp1.cpp
@@ -1,7 +1,7 @@
 #include "TestApp1.h"
 
-TestApp1::TestApp1(DriverInterface* pstDriver, ostream& output)
-	: TestScriptBase(pstDriver, output)
+TestApp1::TestApp1(DriverInterface* pstDriver)
+	: TestScriptBase(pstDriver)
 {
 }
 

--- a/TestShellApplication/TestScripts/TestApp1.h
+++ b/TestShellApplication/TestScripts/TestApp1.h
@@ -3,7 +3,7 @@
 
 class TestApp1 : public TestScriptBase {
 public:
-	TestApp1(DriverInterface* pstDriver, ostream& output);
+	TestApp1(DriverInterface* pstDriver);
 	void _setup() override;
 	void _main() override;
 	void _cleanup() override;

--- a/TestShellApplication/TestScripts/TestApp2.cpp
+++ b/TestShellApplication/TestScripts/TestApp2.cpp
@@ -1,7 +1,7 @@
 #include "TestApp2.h"
 
-TestApp2::TestApp2(DriverInterface* pstDriver, ostream& output)
-	: TestScriptBase(pstDriver, output)
+TestApp2::TestApp2(DriverInterface* pstDriver)
+	: TestScriptBase(pstDriver)
 {
 }
 

--- a/TestShellApplication/TestScripts/TestApp2.h
+++ b/TestShellApplication/TestScripts/TestApp2.h
@@ -3,7 +3,7 @@
 
 class TestApp2 : public TestScriptBase {
 public:
-	TestApp2(DriverInterface* pstDriver, ostream& output);
+	TestApp2(DriverInterface* pstDriver);
 	void _setup() override;
 	void _main() override;
 	void _cleanup() override;

--- a/TestShellApplication/TestScripts/TestScriptBase.cpp
+++ b/TestShellApplication/TestScripts/TestScriptBase.cpp
@@ -1,8 +1,7 @@
 #include "TestScriptBase.h"
 
-TestScriptBase::TestScriptBase(DriverInterface* pstDriver, ostream& output)
+TestScriptBase::TestScriptBase(DriverInterface* pstDriver)
 	: m_pstTestLib(nullptr)
-	, m_out(output)
 {
 	m_pstDevice = new Device(pstDriver);
 }

--- a/TestShellApplication/TestScripts/TestScriptBase.h
+++ b/TestShellApplication/TestScripts/TestScriptBase.h
@@ -4,7 +4,7 @@
 
 class TestScriptBase{
 public:
-	TestScriptBase(DriverInterface* pstDriver, ostream& output);
+	TestScriptBase(DriverInterface* pstDriver);
 	void Run();
 
 protected:
@@ -14,5 +14,4 @@ protected:
 
 	TestLibrary* m_pstTestLib;
 	Device* m_pstDevice;
-	ostream& m_out;
 };


### PR DESCRIPTION
TestLibrary 및 TestScript에서 std::outstream을 사용하고 있어,
이를 Logger를 사용하도록 수정한 PR  입니다.