### PR TITLE
[feature][shell] 재빌드 이슈 해결

### DIFF
--- a/SSD_E.sln
+++ b/SSD_E.sln
@@ -14,6 +14,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestShellApplication-Test",
 		{3FF8CC0E-F94F-4463-9DB3-3E897D6A2B1D} = {3FF8CC0E-F94F-4463-9DB3-3E897D6A2B1D}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestScriptLib", "TestScriptLib\TestScriptLib.vcxproj", "{0CB0D296-8804-4F80-B783-9054CF41C5F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -54,6 +56,14 @@ Global
 		{DD68F35A-4C6D-4186-9A9C-0A26472E8D29}.Release|x64.Build.0 = Release|x64
 		{DD68F35A-4C6D-4186-9A9C-0A26472E8D29}.Release|x86.ActiveCfg = Release|Win32
 		{DD68F35A-4C6D-4186-9A9C-0A26472E8D29}.Release|x86.Build.0 = Release|Win32
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Debug|x64.ActiveCfg = Debug|x64
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Debug|x64.Build.0 = Debug|x64
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Debug|x86.ActiveCfg = Debug|Win32
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Debug|x86.Build.0 = Debug|Win32
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Release|x64.ActiveCfg = Release|x64
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Release|x64.Build.0 = Release|x64
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Release|x86.ActiveCfg = Release|Win32
+		{0CB0D296-8804-4F80-B783-9054CF41C5F1}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TestScriptLib/TestScriptLib.vcxproj
+++ b/TestScriptLib/TestScriptLib.vcxproj
@@ -21,32 +21,32 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
-    <ProjectGuid>{a291a7a5-34da-48c2-9a5c-3252ce244fdb}</ProjectGuid>
-    <RootNamespace>TestShellApplication</RootNamespace>
+    <ProjectGuid>{0cb0d296-8804-4f80-b783-9054cf41c5f1}</ProjectGuid>
+    <RootNamespace>TestScriptLib</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -74,12 +74,15 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;TESTSCRIPTLIB_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -88,26 +91,32 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;TESTSCRIPTLIB_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;TESTSCRIPTLIB_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -116,54 +125,33 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;TESTSCRIPTLIB_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="Device.cpp" />
-    <ClCompile Include="DriverInterface.h" />
-    <ClCompile Include="EraseCommand.cpp" />
-    <ClCompile Include="FlushCommand.cpp" />
-    <ClCompile Include="FileLoggerPrinter.cpp" />
-    <ClCompile Include="Logger.cpp" />
-    <ClCompile Include="main.cpp" />
-    <ClCompile Include="OutstreamLoggerPrinter.cpp" />
-    <ClCompile Include="ReadCommand.cpp" />
-    <ClCompile Include="Runner.cpp" />
-    <ClCompile Include="Shell.cpp" />
-    <ClCompile Include="ShellException.cpp" />
-    <ClCompile Include="SSDDriver.cpp" />
-    <ClCompile Include="TestLibrary.cpp" />
-    <ClCompile Include="TestLibraryCommandInvoker.cpp" />
-    <ClCompile Include="TestScripts\TestScriptInvoker.cpp" />
-    <ClCompile Include="TestScripts\TestScriptInvoker.h" />
-    <ClCompile Include="WriteCommand.cpp" />
+    <ClInclude Include="..\TestShellApplication\TestLibraryCommandInvokerInterface.h" />
+    <ClInclude Include="..\TestShellApplication\TestLibraryInterface.h" />
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestApp1.h" />
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestApp2.h" />
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestScriptBase.h" />
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestScriptInterface.h" />
+    <ClInclude Include="framework.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="CommandInterface.h" />
-    <ClInclude Include="Device.h" />
-    <ClInclude Include="EraseCommand.h" />
-    <ClInclude Include="FlushCommand.h" />
-    <ClInclude Include="FileLoggerPrinter.h" />
-    <ClInclude Include="Logger.h" />
-    <ClInclude Include="LoggerPrinter.h" />
-    <ClInclude Include="OutstreamLoggerPrinter.h" />
-    <ClInclude Include="ReadCommand.h" />
-    <ClInclude Include="Runner.h" />
-    <ClInclude Include="Shell.h" />
-    <ClInclude Include="ShellException.h" />
-    <ClInclude Include="SSDDriver.h" />
-    <ClInclude Include="TestLibrary.h" />
-    <ClInclude Include="TestLibraryCommandInvoker.h" />
-    <ClInclude Include="TestScripts\TestScriptInterface.h" />
-    <ClInclude Include="WriteCommand.h" />
+    <ClCompile Include="..\TestShellApplication\TestScripts\TestApp1.cpp" />
+    <ClCompile Include="..\TestShellApplication\TestScripts\TestApp2.cpp" />
+    <ClCompile Include="..\TestShellApplication\TestScripts\TestScriptBase.cpp" />
+    <ClCompile Include="dllmain.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/TestScriptLib/TestScriptLib.vcxproj.filters
+++ b/TestScriptLib/TestScriptLib.vcxproj.filters
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="TestScript">
+      <UniqueIdentifier>{7e6e5668-95ba-4f50-814c-e65e4ee708a0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="TestLibInvoker">
+      <UniqueIdentifier>{6cc51a59-0239-4807-bd67-225bd99ca794}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="framework.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestApp1.h">
+      <Filter>TestScript</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestApp2.h">
+      <Filter>TestScript</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestScriptBase.h">
+      <Filter>TestScript</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TestShellApplication\TestScripts\TestScriptInterface.h">
+      <Filter>TestScript</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TestShellApplication\TestLibraryCommandInvokerInterface.h">
+      <Filter>TestLibInvoker</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TestShellApplication\TestLibraryInterface.h">
+      <Filter>TestLibInvoker</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TestShellApplication\TestScripts\TestApp1.cpp">
+      <Filter>TestScript</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TestShellApplication\TestScripts\TestApp2.cpp">
+      <Filter>TestScript</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TestShellApplication\TestScripts\TestScriptBase.cpp">
+      <Filter>TestScript</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/TestScriptLib/dllmain.cpp
+++ b/TestScriptLib/dllmain.cpp
@@ -1,0 +1,33 @@
+// dllmain.cpp : Defines the entry point for the DLL application.
+#include <Windows.h>
+
+#include "../TestShellApplication/TestScripts/TestApp1.h"
+#include "../TestShellApplication/TestScripts/TestApp2.h"
+
+#include "../TestShellApplication/TestLibraryCommandInvoker.h"
+
+
+#include <string>
+#include <map>
+
+BOOL APIENTRY DllMain( HMODULE hModule,
+                       DWORD  ul_reason_for_call,
+                       LPVOID lpReserved
+                     )
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+extern "C" __declspec(dllexport) void GetTestSciprtList(TestLibCommandInvoker* pstTestLibCommandInvoker, std::map<string, TestScriptInterface*>& mapCommand)
+{
+    mapCommand["testapp1"] = new TestApp1(pstTestLibCommandInvoker);
+    mapCommand["testapp2"] = new TestApp2(pstTestLibCommandInvoker);
+}

--- a/TestScriptLib/framework.h
+++ b/TestScriptLib/framework.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+// Windows Header Files
+#include <windows.h>

--- a/TestShellApplication-Test/TestShellApplication-Test.vcxproj.filters
+++ b/TestShellApplication-Test/TestShellApplication-Test.vcxproj.filters
@@ -4,7 +4,6 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="SSDDriver_test.cpp" />
     <ClCompile Include="test.cpp" />
-    <ClCompile Include="TestAppCommand_test.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc" />
     <ClCompile Include="Runner_test.cpp" />

--- a/TestShellApplication/Shell.cpp
+++ b/TestShellApplication/Shell.cpp
@@ -36,7 +36,7 @@ bool Shell::handleCommand(string strLine)
         return false;
     }
 
-    TestScriptBase* targetScript = m_pstTestScriptInvoker->GetTestScript(strCommand);
+    TestScriptInterface* targetScript = m_pstTestScriptInvoker->GetTestScript(strCommand);
     if (targetScript) {
         m_pstTestScriptInvoker->Run(targetScript);
         return false;

--- a/TestShellApplication/TestLibrary.h
+++ b/TestShellApplication/TestLibrary.h
@@ -1,14 +1,9 @@
 #pragma once
 #include "Device.h"
+#include "TestLibraryInterface.h"
 
 #include <iomanip>
 #include <iostream>
-
-class TestLibrary {
-public:
-	virtual ~TestLibrary() = default;
-	virtual void execute(const vector<string>& vCommandList, int nStartLba, int nEndLba, const string& strData) const = 0;
-};
 
 class TestLibWrite : public TestLibrary {
 public:

--- a/TestShellApplication/TestLibraryCommandInvoker.h
+++ b/TestShellApplication/TestLibraryCommandInvoker.h
@@ -1,12 +1,16 @@
 #pragma once
 #include "TestLibrary.h"
+#include "TestLibraryCommandInvokerInterface.h"
 #include <map>
 
-class TestLibCommandInvoker {
+class TestLibCommandInvoker
+	: public TestLibCommandInvokerdInterface
+{
 public:
 	TestLibCommandInvoker(DriverInterface* pstDriver);
-	TestLibrary* GetFunction(string strCommand);
-	void Run(TestLibrary* stFunction, const vector<string>& vCommandList = {}, int nStartLba = -1, int nEndLba = -1, const string& strData = "");
+	
+	TestLibrary* GetFunction(string strCommand) override;
+	void Run(TestLibrary* stFunction, const vector<string>& vCommandList = {}, int nStartLba = -1, int nEndLba = -1, const string& strData = "") override;
 
 private:
 	std::map<string, TestLibrary*> m_mapCommand;

--- a/TestShellApplication/TestLibraryCommandInvokerInterface.h
+++ b/TestShellApplication/TestLibraryCommandInvokerInterface.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "TestLibraryInterface.h"
+
+#include <string>
+#include <vector>
+
+using std::string;
+using std::vector;
+
+#define interface struct
+
+interface TestLibCommandInvokerdInterface
+{
+public:
+	virtual ~TestLibCommandInvokerdInterface() {}
+
+public:
+	virtual TestLibrary* GetFunction(string strCommand) = 0;
+	virtual void Run(TestLibrary* stFunction, const vector<string>& vCommandList = {}, int nStartLba = -1, int nEndLba = -1, const string& strData = "") = 0;
+
+};

--- a/TestShellApplication/TestLibraryInterface.h
+++ b/TestShellApplication/TestLibraryInterface.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#define interface struct
+
+#include <string>
+#include <vector>
+
+using std::string;
+using std::vector;
+
+interface TestLibrary {
+public:
+	virtual ~TestLibrary() {}
+
+public:
+	virtual void execute(const vector<string>& vCommandList, int nStartLba, int nEndLba, const string& strData) const = 0;
+};

--- a/TestShellApplication/TestScripts/TestApp1.cpp
+++ b/TestShellApplication/TestScripts/TestApp1.cpp
@@ -1,6 +1,6 @@
 #include "TestApp1.h"
 
-TestApp1::TestApp1(TestLibCommandInvoker* pstTestLibCommandInvoker)
+TestApp1::TestApp1(TestLibCommandInvokerdInterface* pstTestLibCommandInvoker)
 	: TestScriptBase(pstTestLibCommandInvoker)
 {
 }

--- a/TestShellApplication/TestScripts/TestApp1.h
+++ b/TestShellApplication/TestScripts/TestApp1.h
@@ -3,7 +3,7 @@
 
 class TestApp1 : public TestScriptBase {
 public:
-	TestApp1(TestLibCommandInvoker* pstTestLibCommandInvoker);
+	TestApp1(TestLibCommandInvokerdInterface* pstTestLibCommandInvoker);
 
 	void _setup() override;
 	void _main() override;

--- a/TestShellApplication/TestScripts/TestApp2.cpp
+++ b/TestShellApplication/TestScripts/TestApp2.cpp
@@ -1,6 +1,6 @@
 #include "TestApp2.h"
 
-TestApp2::TestApp2(TestLibCommandInvoker* pstTestLibCommandInvoker)
+TestApp2::TestApp2(TestLibCommandInvokerdInterface* pstTestLibCommandInvoker)
 	: TestScriptBase(pstTestLibCommandInvoker)
 {
 }

--- a/TestShellApplication/TestScripts/TestApp2.h
+++ b/TestShellApplication/TestScripts/TestApp2.h
@@ -3,7 +3,7 @@
 
 class TestApp2 : public TestScriptBase {
 public:
-	TestApp2(TestLibCommandInvoker* pstTestLibCommandInvoker);
+	TestApp2(TestLibCommandInvokerdInterface* pstTestLibCommandInvoker);
 
 	void _setup() override;
 	void _main() override;

--- a/TestShellApplication/TestScripts/TestScriptBase.cpp
+++ b/TestShellApplication/TestScripts/TestScriptBase.cpp
@@ -1,6 +1,6 @@
 #include "TestScriptBase.h"
 
-TestScriptBase::TestScriptBase(TestLibCommandInvoker* pstTestLibCommandInvoker)
+TestScriptBase::TestScriptBase(TestLibCommandInvokerdInterface* pstTestLibCommandInvoker)
 	: m_pstTestLibCommandInvoker(pstTestLibCommandInvoker)
 {
 }

--- a/TestShellApplication/TestScripts/TestScriptBase.h
+++ b/TestShellApplication/TestScripts/TestScriptBase.h
@@ -1,16 +1,19 @@
 #pragma once
 #include "../Device.h"
-#include "../TestLibraryCommandInvoker.h"
+#include "../TestLibraryCommandInvokerInterface.h"
+#include "TestScriptInterface.h"
 
-class TestScriptBase{
+class TestScriptBase
+	: public TestScriptInterface
+{
 public:
-	TestScriptBase(TestLibCommandInvoker* pstTestLibCommandInvoker);
-	void Run();
+	TestScriptBase(TestLibCommandInvokerdInterface* pstTestLibCommandInvoker);
+	void Run() override;
 
 protected:
 	virtual void _setup() = 0;
 	virtual void _main() = 0;
 	virtual void _cleanup() = 0;
 
-	TestLibCommandInvoker* m_pstTestLibCommandInvoker;
+	TestLibCommandInvokerdInterface* m_pstTestLibCommandInvoker;
 };

--- a/TestShellApplication/TestScripts/TestScriptInterface.h
+++ b/TestShellApplication/TestScripts/TestScriptInterface.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define interface struct
+
+interface TestScriptInterface {
+public:
+	virtual ~TestScriptInterface() {}
+
+public:
+	virtual void Run() = 0;
+};

--- a/TestShellApplication/TestScripts/TestScriptInvoker.h
+++ b/TestShellApplication/TestScripts/TestScriptInvoker.h
@@ -1,16 +1,17 @@
 #pragma once
-#include "TestApp1.h"
-#include "TestApp2.h"
+#include "../TestLibraryCommandInvoker.h"
+#include "TestScriptInterface.h"
+
 #include <map>
 
 class TestScriptInvoker {
 public:
 	TestScriptInvoker(TestLibCommandInvoker* pstTestLibCommandInvoker);
-	TestScriptBase* GetTestScript(string strCommand);
-	void Run(TestScriptBase* stFunction);
+	TestScriptInterface* GetTestScript(string strCommand);
+	void Run(TestScriptInterface* stFunction);
 
 private:
-	std::map<string, TestScriptBase*> m_mapCommand;
+	std::map<string, TestScriptInterface*> m_mapCommand;
 
 	void _initCommands(TestLibCommandInvoker* pstTestLibCommandInvoker);
 };

--- a/TestShellApplication/TestShellApplication.vcxproj.filters
+++ b/TestShellApplication/TestShellApplication.vcxproj.filters
@@ -42,15 +42,6 @@
     <ClCompile Include="TestLibrary.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
-    <ClCompile Include="TestScripts\TestApp1.cpp">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
-    <ClCompile Include="TestScripts\TestApp2.cpp">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
-    <ClCompile Include="TestScripts\TestScriptBase.cpp">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
     <ClCompile Include="EraseCommand.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
@@ -104,15 +95,6 @@
     <ClInclude Include="Shell.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
-    <ClInclude Include="TestScripts\TestApp1.h">
-      <Filter>헤더 파일</Filter>
-    </ClInclude>
-    <ClInclude Include="TestScripts\TestApp2.h">
-      <Filter>헤더 파일</Filter>
-    </ClInclude>
-    <ClInclude Include="TestScripts\TestScriptBase.h">
-      <Filter>헤더 파일</Filter>
-    </ClInclude>
     <ClInclude Include="EraseCommand.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
@@ -139,6 +121,9 @@
     </ClInclude>
     <ClInclude Include="LoggerPrinter.h">
       <Filter>Logger</Filter>
+    </ClInclude>
+    <ClInclude Include="TestScripts\TestScriptInterface.h">
+      <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
`TestScriptLib` DLL project를 생성하여,
TestApp1/2 class를 해당 project에서 관리하도록 하였습니다.
(신규 Test Script는 DLL project에서 생성하면 됩니다.)

TestShellApplication에서는 해당 dll을 load하여 사용하도록 하였습니다.
`TestScriptInvoker::_initCommand()` 함수를 확인하시면 dll loading하는 로직이 있습니다.

시간 상, refactoring은 진행하지 못하였습니다.
양해 부탁드립니다.