### PR TITLE
[fix][Help] help message에 잘못 나온 값 수정합니다. 

### DIFF
--- a/TestShellApplication/Shell.cpp
+++ b/TestShellApplication/Shell.cpp
@@ -69,7 +69,7 @@ void Shell::_printHelp()
 \n\
 [lba] : decimal only, range = [0, 99]\n\
 [data] : hexadecimal only, range = [0x00000000, 0xFFFFFFFF]\n\
-[block count] : decimal only, range = [0, 10] (erase) \n\
+[block count] : decimal only, range = [1, 10] (erase) \n\
 ";
     LOG(strHelp);
 }

--- a/TestShellApplication/Shell.cpp
+++ b/TestShellApplication/Shell.cpp
@@ -69,7 +69,7 @@ void Shell::_printHelp()
 \n\
 [lba] : decimal only, range = [0, 99]\n\
 [data] : hexadecimal only, range = [0x00000000, 0xFFFFFFFF]\n\
-[block count] : decimal only, range = [1, 10] (erase) \n\
+[block count] : decimal only, range = [1, infinity] (erase) \n\
 ";
     LOG(strHelp);
 }


### PR DESCRIPTION
* erase command에서 block count 0은 지원하지 않으나 Help message에서는 0부터 지원하는 것처럼 나와있어서 수정했습니다.
* block count의 상한의 제한이 없음으로 설명도 수정합니다.