### PR TITLE
[fix][shell] `erase` command에서 block에서 format check 함수를 호출 누락

### DIFF
--- a/TestShellApplication/EraseCommand.cpp
+++ b/TestShellApplication/EraseCommand.cpp
@@ -21,6 +21,7 @@ EraseCommand& EraseCommand::setLBA(string strLBA)
 EraseCommand& EraseCommand::setBlkCnt(string strData)
 {
 	_checkLBAIsValid();
+	_checkBlkCntFormat(strData);
 	_updateBlkCnt(strData);
 	_checkBlkRange();
 	return *this;


### PR DESCRIPTION
`erase 1 123X` 과 같이 [block_count]에 잘못된 format을 체크하지 못하는 문제를 수정한 PR 입니다.

format check하는 함수가 구현되어 있었으나,
호출이 되지 않았던 부분으로 함수 호출하도록 수정하였습니다.